### PR TITLE
Use PAT for Go update PRs

### DIFF
--- a/.github/workflows/update_go_version.yaml
+++ b/.github/workflows/update_go_version.yaml
@@ -24,6 +24,7 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
         with:
+          token: ${{ secrets.PR_WORKFLOW_TOKEN }}
           commit-message: Update Go version to ${{ steps.update.outputs.latest-version }}
           title: Update Go version to ${{ steps.update.outputs.latest-version }}
           body: |


### PR DESCRIPTION
Uses the PR_WORKFLOW_TOKEN secret for update-go-version PR creation so downstream pull_request workflows will run.