### PR TITLE
Use v1 of shared Go update action

### DIFF
--- a/.github/workflows/update_go_version.yaml
+++ b/.github/workflows/update_go_version.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Update go.mod
         id: update
-        uses: faisal-memon/update-go-mod-action@main
+        uses: faisal-memon/update-go-mod-action@v1
 
       - name: Create pull request
         if: steps.update.outputs.changed == 'true'


### PR DESCRIPTION
Updates the Go version updater workflow to use the published faisal-memon/update-go-mod-action@v1 tag instead of main.