### PR TITLE
Add version details to tooling PR body

### DIFF
--- a/.github/workflows/update_tooling.yaml
+++ b/.github/workflows/update_tooling.yaml
@@ -33,6 +33,37 @@ jobs:
         if: steps.update-go.outputs.changed == 'true' || steps.update-lint.outputs.changed == 'true'
         run: make lint-fix
 
+      - name: Build pull request body
+        if: steps.update-go.outputs.changed == 'true' || steps.update-lint.outputs.changed == 'true'
+        run: |
+          cat > pr_body.md <<EOF
+          Updates repository Go tooling.
+
+          Changes included in this PR:
+          EOF
+
+          if [ "${{ steps.update-go.outputs.changed }}" = "true" ]; then
+            cat >> pr_body.md <<EOF
+          - Go version: \`${{ steps.update-go.outputs.previous-version }}\` -> \`${{ steps.update-go.outputs.current-version }}\`
+          EOF
+          fi
+
+          if [ "${{ steps.update-lint.outputs.changed }}" = "true" ]; then
+            if [ -n "${{ steps.update-lint.outputs.previous-action-version }}" ] && [ -n "${{ steps.update-lint.outputs.current-action-version }}" ]; then
+              cat >> pr_body.md <<EOF
+          - golangci-lint-action: \`${{ steps.update-lint.outputs.previous-action-version }}\` -> \`${{ steps.update-lint.outputs.current-action-version }}\`
+          EOF
+            fi
+            if [ -n "${{ steps.update-lint.outputs.previous-lint-version }}" ] && [ -n "${{ steps.update-lint.outputs.current-lint-version }}" ]; then
+              cat >> pr_body.md <<EOF
+          - golangci-lint version: \`${{ steps.update-lint.outputs.previous-lint-version }}\` -> \`${{ steps.update-lint.outputs.current-lint-version }}\`
+          EOF
+            fi
+            cat >> pr_body.md <<EOF
+          - Applied \`make lint-fix\` after tooling updates
+          EOF
+          fi
+
       - name: Create pull request
         if: steps.update-go.outputs.changed == 'true' || steps.update-lint.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v7
@@ -40,12 +71,5 @@ jobs:
           token: ${{ secrets.PR_WORKFLOW_TOKEN }}
           commit-message: Update Go tooling
           title: Update Go tooling
-          body: |
-            Updates repository Go tooling.
-
-            This workflow may include:
-            - a `go.mod` Go version update
-            - golangci-lint workflow updates
-            - `.tool_versions` updates
-            - `make lint-fix` output after tooling changes
+          body-path: pr_body.md
           branch: chore/update-go-tooling


### PR DESCRIPTION
Improves the Update Tooling workflow so bot-created PRs include before/after version details for Go and golangci-lint changes.