### PR TITLE
Use simple-semver in release workflow

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Bump and write version tag
         id: bump
-        uses: faisal-memon/semver-bump-action@v0.0.9
+        uses: faisal-memon/simple-semver@v0.0.9
         with:
           version-bump: ${{ github.event_name == 'workflow_dispatch' && inputs.version_bump || '' }}
           write-tag: "true"


### PR DESCRIPTION
## Summary
- update `.github/workflows/release_build.yaml` to use `faisal-memon/simple-semver@v0.0.9`
- replace old action path `faisal-memon/semver-bump-action@v0.0.9`

## Why
- align with the renamed action repository
- keep release workflow functional after repo rename
