### PR TITLE
Bump simple-semver to v0.0.15 and pass github token

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -42,10 +42,11 @@ jobs:
 
       - name: Bump and write version tag
         id: bump
-        uses: faisal-memon/simple-semver@v0.0.9
+        uses: faisal-memon/simple-semver@v0.0.15
         with:
           version-bump: ${{ github.event_name == 'workflow_dispatch' && inputs.version_bump || '' }}
           write-tag: "true"
+          github-token: ${{ github.token }}
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v3


### PR DESCRIPTION
## Summary
- bump release workflow action from faisal-memon/simple-semver@v0.0.9 to @v0.0.15
- pass github-token to support label-based bump resolution when version-bump is empty

## Why
- validates and adopts the updated label-driven bump logic
- avoids fail-fast prerequisite errors in the new action version

## Test plan
- merge a PR with one bump label (patch/minor/major) and verify release tag bump matches label
- merge a PR with no bump label and verify patch default
