### PR TITLE
Use pr-label-semver action in release workflow

### DIFF
--- a/.github/workflows/release_build.yaml
+++ b/.github/workflows/release_build.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Bump and write version tag
         id: bump
-        uses: faisal-memon/simple-semver@v0.0.15
+        uses: faisal-memon/pr-label-semver@v0
         with:
           version-bump: ${{ github.event_name == 'workflow_dispatch' && inputs.version_bump || '' }}
           write-tag: "true"


### PR DESCRIPTION
## Summary
- update release workflow action reference from faisal-memon/simple-semver to faisal-memon/pr-label-semver
- pin to v0 channel for ongoing compatible updates

## Notes
- behavior remains the same; this aligns with the renamed action
