### PR TITLE
Update Go tooling

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clarendonjbbp/parent-square-to-csv
 
-go 1.26.3
+go 1.26.4
 
 require golang.org/x/term v0.44.0
 


### PR DESCRIPTION
Updates repository version updates.

Changes included in this PR:
- Go version: `1.26.3` -> `1.26.4`
- golangci-lint version: `v2.12.2` -> `v2.12.2`
- Ran `make lint-fix` after version updates
